### PR TITLE
remove 0.27 and add 0.30 e2e test

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -88,25 +88,6 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
-  - name: pull-init-agent-test-e2e-kcp-0.27
-    always_run: true
-    decorate: true
-    clone_uri: "https://github.com/kcp-dev/init-agent"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.5-1
-          command:
-            - hack/ci/run-e2e-tests.sh
-          env:
-            - name: KCP_VERSION
-              value: "0.27.1"
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 2
-
   - name: pull-init-agent-test-e2e-kcp-0.28
     always_run: true
     decorate: true
@@ -140,6 +121,25 @@ presubmits:
           env:
             - name: KCP_VERSION
               value: "0.29.0"
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pull-init-agent-test-e2e-kcp-0.30
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/init-agent"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.25.5-1
+          command:
+            - hack/ci/run-e2e-tests.sh
+          env:
+            - name: KCP_VERSION
+              value: "0.30.0"
           resources:
             requests:
               memory: 4Gi

--- a/test/e2e/clusterinit/wait_for_ready_test.go
+++ b/test/e2e/clusterinit/wait_for_ready_test.go
@@ -31,6 +31,7 @@ import (
 	kcptenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
@@ -193,51 +194,21 @@ spec:
 	// Verify the CRD exists in the target workspace and is Established
 	targetClient := kcpClusterClient.Cluster(rootCluster.Join(targetWorkspace))
 
-	crd := utils.YAMLToUnstructured(t, `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: widgets.example.com
-`)
-
-	if err := targetClient.Get(ctx, types.NamespacedName{Name: crd.GetName()}, crd); err != nil {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := targetClient.Get(ctx, types.NamespacedName{Name: "widgets.example.com"}, crd); err != nil {
 		t.Fatalf("Failed to find CRD in target workspace: %v", err)
 	}
 
 	// Verify the CRD has the Established condition set to True
-	conditions, found, err := getConditions(crd.Object)
-	if err != nil || !found {
-		t.Fatal("CRD does not have conditions in status")
-	}
-
 	established := false
-	for _, c := range conditions {
-		condition, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		cType := condition["type"].(string)
-		cStatus := condition["status"].(string)
-		if cType == "Established" && cStatus == "True" {
+	for _, condition := range crd.Status.Conditions {
+		if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
 			established = true
 			break
 		}
 	}
 
 	if !established {
-		t.Fatal("Expected CRD to have Established=True condition, but it was not found or not True")
+		t.Fatal("Expected CRD to have Established=True condition, but has not.")
 	}
-}
-
-func getConditions(obj map[string]any) ([]any, bool, error) {
-	status, ok := obj["status"].(map[string]any)
-	if !ok {
-		return nil, false, nil
-	}
-	conditions, ok := status["conditions"].([]any)
-	if !ok {
-		return nil, false, nil
-	}
-	return conditions, true, nil
 }

--- a/test/utils/fixtures.go
+++ b/test/utils/fixtures.go
@@ -93,7 +93,10 @@ func WaitForWorkspaceInitialization(t *testing.T, ctx context.Context, clusterCl
 			return false, err
 		}
 
-		return len(ws.Status.Initializers) == 0, nil
+		// Make sure to also look for a cluster ID, otherwise this wait loop might
+		// be so fast, it finishes between the first initializer was added and before
+		// kcp even assigned the cluster name.
+		return ws.Spec.Cluster != "" && len(ws.Status.Initializers) == 0, nil
 	})
 	if err != nil {
 		t.Fatalf("Failed to wait for workspace to be initialized: %v", err)


### PR DESCRIPTION
## Summary
This updates our e2e tests to use the latest kcp version, and removing testing for 0.27, which is now not supported upstream anymore. I also made the tests a lot more stable on slower CI nodes.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Add e2e tests for kcp 0.30.
```
