### PR TITLE
fix branch naming in release docs

### DIFF
--- a/docs/content/contributing/releasing.md
+++ b/docs/content/contributing/releasing.md
@@ -10,14 +10,14 @@ The guide describes how to release a new version of the init-agent.
 ## Minor Release
 
 Minor releases (0.x) are tagged directly on the `main` branch and the `v0.X.0`
-tag represents where the corresponding `release/v0.X` branch branches off.
+tag represents where the corresponding `release-0.X` branch branches off.
 
 1. Checkout the desired `main` branch commit.
 1. Tag the main module: `git tag -m "version 0.X" v0.X.0`
 1. Tag the SDK module: `git tag -m "SDK version 0.X" sdk/v0.X.0`
 1. Push the tags: `git push upstream v0.X.0 sdk/v0.X.0`
-1. Create the release branch: `git checkout -B release-v0.X`
-1. Push the release branch: `git push -u upstream release-v0.X`
+1. Create the release branch: `git checkout -B release-0.X`
+1. Push the release branch: `git push -u upstream release-0.X`
 
 Once the tag and branch have been pushed, the documentation has to be manually
 updated to include the new minor release.
@@ -32,7 +32,7 @@ https://docs.kcp.io/init-agent/.
 
 Patch releases (v0.x.y) are tagged with in a release branch.
 
-1. Checkout the desired `release/v0.X` branch commit.
+1. Checkout the desired `release-0.X` branch commit.
 1. Tag the main module: `git tag -m "version 0.X.Y" v0.X.Y`
 1. Tag the SDK module: `git tag -m "SDK version 0.X.Y" sdk/v0.X.Y`
 1. Push the tags: `git push upstream v0.X.Y sdk/v0.X.Y`


### PR DESCRIPTION
## Summary
The `release/vN.M` naming scheme is something we use at Kubermatic, but at kcp and related projects we're using `release-N.M`. There is already the `release-0.1` branch in this repo, so let's make sure future branches follow this pattern.

## What Type of PR Is This?
/kind documentation

## Release Notes
```release-note
NONE
```
