### PR TITLE
bump to Go 1.25.10

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.25.9
+          go-version: v1.25.10
           cache: true
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 #tag=v6.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.25.9
+          go-version: v1.25.10
           cache: true
 
       - name: Delete non-semver tags

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
           command:
             - hack/ci/verify.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
           command:
             - make
             - lint
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
           command:
             - make
             - test
@@ -96,7 +96,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:
@@ -134,7 +134,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
           command:
             - hack/ci/run-e2e-tests.sh
           env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.25.9 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.25.10 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
Pure maintenance.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.25.10
```
